### PR TITLE
Remove channel due to repeated promotion of scam content

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Channel-specific. This channel's content is mainly comprised of:
 - :memo: [@devops_sre_notes](https://t.me/devops_sre_notes) :fire::fire::fire: — articles and books for DevOps & SRE.
 - :link: [@securedevops](https://t.me/securedevops) :fire: — tools and books for DevOps, DevSecOps & SRE.
 - :memo: [@CatOps](https://t.me/catops) :fire::fire: — news and notes about DevOps, SRE, and more.
-- :memo: [@prodevopsguy](https://t.me/prodevopsguy) :fire::fire::fire: — daily DevOps-related tips, job interview questions, etc.
 - :link: [@DevOps101](https://t.me/DevOps101) — DevOps and SRE news, tools and articles.
 - :memo: [@mkdev_me](https://t.me/mkdev_me) — articles, news roundups, and podcast announcements from mkdev. The main topics are DevOps, SRE, cloud (AWS & GCP), and AI.
 - :link: [@devops_toolkit](https://t.me/devops_toolkit) — articles and tools for DevOps.


### PR DESCRIPTION
This PR removes a Telegram channel https://t.me/prodevopsguy from the list due to repeated promotion of websites that appear to be scams or misleading services.

Reasons:
- The channel regularly advertises external sites with typical scam patterns (fake promises, unclear ownership, no verifiable information).
- This conflicts with the goal of keeping the list useful and safe for readers.
- Awesome lists usually avoid promoting channels that may expose users to fraud.

Latest example: https://t.me/prodevopsguy/3116

<img width="527" height="720" alt="image" src="https://github.com/user-attachments/assets/e63b82ff-72f5-43a3-95de-24ebc4685f3e" />
